### PR TITLE
Add step to make sure the gem user dir exists

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,6 +123,8 @@ jobs:
       with:
         name: Gem
         path: pkg
+    - name: 🌵 Ensure ~/.gem exists
+      run: mkdir -p ~/.gem
     - name: 📦 Publish to GitHub Packages
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['3.1', '3.2']
-        os: [ubuntu-latest, macOS-latest] # , windows-latest
+        os: [ubuntu-latest] # , macOS-latest, windows-latest
     steps:
     - name: 🏁 Checkout
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/lib/dependabot/linguist/version.rb
+++ b/lib/dependabot/linguist/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# change toggle
+
 module Dependabot
   module Linguist
     VERSION = "0.217.0"


### PR DESCRIPTION
# What issue is this addressing?
Fixes the error on the build from merging PR #78 
## What _type_ of issue is this addressing?
bug
## What this PR does | solves
The upgrade to a new ruby version for some reason means the `~/.gem` folder is no longer automatically present, so manually make sure it exists before echoing to it.
