### PR TITLE
remove the toggle comment

### DIFF
--- a/lib/dependabot/linguist/version.rb
+++ b/lib/dependabot/linguist/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# change toggle
-
 module Dependabot
   module Linguist
     VERSION = "0.217.0"


### PR DESCRIPTION
# What issue is this addressing?
Re-releasing merge from pr #78 after fixing what broke it in #79 
## What _type_ of issue is this addressing?
enhancement
## What this PR does | solves
Toggles the version file after
```
git tag -d v0.217.0
git push --delete origin v0.217.0
```
